### PR TITLE
TaskQueue fields private -> protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.4 (2018-01-11)
+## "private" -> "protected"
+* Make TaskQueue fields "protected" so that they are accessible in descendants
+
 # 1.0.2 (2017-09-14)
 ## Dependencies
 * Upgraded all dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-task-queue",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A class used to execute tasks in order.",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/src/task-queue.ts
+++ b/src/task-queue.ts
@@ -7,10 +7,10 @@ import {Observable} from "typescript-observable";
 import {StartEvent, StopEvent} from "./task-events";
 
 export class TaskQueue extends Observable implements ITaskQueue {
-    private tasks : Function[] = [];
-    private isRunning : boolean = false;
-    private isStopped : boolean = false;
-    private config : ITaskQueueConfig;
+    protected tasks : Function[] = [];
+    protected isRunning : boolean = false;
+    protected isStopped : boolean = false;
+    protected config : ITaskQueueConfig;
 
     /**
      *


### PR DESCRIPTION
In my project I want to modify the behavior of `enqueue` function of `TaskQueue`, so I need the access to `tasks` field. In general, it makes sense to provide the access to descendants